### PR TITLE
Fix problems with k8s deployment files

### DIFF
--- a/deploy/k8s/jaeger.yml
+++ b/deploy/k8s/jaeger.yml
@@ -15,23 +15,17 @@ spec:
     spec:
       containers:
       - name: jaeger
-        image: jaegertracing/all-in-one:latest
+        image: jaegertracing/jaeger:2.2.0
         ports:
-        - containerPort: 5775
-          protocol: UDP
-        - containerPort: 6831
-          protocol: UDP
-        - containerPort: 6832
-          protocol: UDP
-        - containerPort: 5778
+        - containerPort: 4317  # OTLP gRPC
           protocol: TCP
-        - containerPort: 16686
+        - containerPort: 4318  # OTLP HTTP
           protocol: TCP
-        - containerPort: 14250
+        - containerPort: 9411  # Zipkin
           protocol: TCP
-        - containerPort: 14268
+        - containerPort: 5778  # serve configs
           protocol: TCP
-        - containerPort: 14269
+        - containerPort: 16686 # serve UI
           protocol: TCP
         env:
         - name: COLLECTOR_ZIPKIN_HOST_PORT
@@ -46,14 +40,18 @@ metadata:
   namespace: observability
 spec:
   ports:
-  - name: agent-compact
-    port: 6831
-    protocol: UDP
-    targetPort: 6831
-  - name: agent-binary
-    port: 6832
-    protocol: UDP
-    targetPort: 6832
+  - name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  - name: collector-zipkin
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
   - name: agent-configs
     port: 5778
     protocol: TCP
@@ -62,17 +60,5 @@ spec:
     port: 16686
     protocol: TCP
     targetPort: 16686
-  - name: collector-grpc
-    port: 14250
-    protocol: TCP
-    targetPort: 14250
-  - name: collector-http
-    port: 14268
-    protocol: TCP
-    targetPort: 14268
-  - name: collector-zipkin
-    port: 9411
-    protocol: TCP
-    targetPort: 9411
   selector:
     app: jaeger

--- a/deploy/k8s/opa-configmap.yml
+++ b/deploy/k8s/opa-configmap.yml
@@ -9,12 +9,12 @@ data:
     
     default allow = true
     
-    violation[msg] {
+    violation[msg] if {
       input.risk_level == "critical"
       msg := "Critical risk level detected"
     }
     
-    violation[msg] {
+    violation[msg] if {
       input.token_count > 1000
       msg := "Token limit exceeded"
     }

--- a/deploy/k8s/opa-deployment.yml
+++ b/deploy/k8s/opa-deployment.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: opa
-        image: openpolicyagent/opa:latest
+        image: openpolicyagent/opa:1.1.0
         args:
         - "run"
         - "--server"

--- a/deploy/k8s/otel-configmap.yml
+++ b/deploy/k8s/otel-configmap.yml
@@ -21,10 +21,10 @@ data:
     exporters:
       prometheus:
         endpoint: "0.0.0.0:8889"
-      logging:
-        loglevel: debug
-      jaeger:
-        endpoint: "jaeger:14250"
+      debug:
+        verbosity: detailed
+      otlp:
+        endpoint: "jaeger:4317"
         tls:
           insecure: true
     
@@ -33,8 +33,8 @@ data:
         traces:
           receivers: [otlp]
           processors: [batch]
-          exporters: [jaeger, logging]
+          exporters: [otlp, debug]
         metrics:
           receivers: [otlp]
           processors: [batch]
-          exporters: [prometheus, logging]
+          exporters: [prometheus, debug]

--- a/deploy/k8s/otel-deployment.yml
+++ b/deploy/k8s/otel-deployment.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: otel-collector
-        image: otel/opentelemetry-collector-contrib:latest
+        image: otel/opentelemetry-collector-contrib:0.118.0
         args:
           - "--config=/conf/otel-collector-config.yaml"
         ports:

--- a/deploy/k8s/prom-deployment.yml
+++ b/deploy/k8s/prom-deployment.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: prom/prometheus:latest
+        image: prom/prometheus:v3.1.0
         args:
         - "--config.file=/etc/prometheus/prometheus.yml"
         ports:


### PR DESCRIPTION
The otel collector config was using deprecated features that are now removed. The latest OPA release has more strict parsing requirements for .rego files. An old v1.x version of jaeger was being used.

Pin all components at the latest versions and update the config to match.